### PR TITLE
add cache workflow for go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,14 @@ jobs:
           go-version: ${{matrix.go-version}}
         id: go
 
+      - name: Cache Go modules packages
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 /patsch
 /coverage.out
 /coverage.html
+.idea/


### PR DESCRIPTION
This should create a cache for go dependencies based on the checksum of go.mod